### PR TITLE
fix: pnpm v11 のビルドスクリプト承認設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml package.json tsconfig.json ./
+COPY pnpm-lock.yaml package.json tsconfig.json pnpm-workspace.yaml ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
   esbuild: true
+confirmModulesPurge: false


### PR DESCRIPTION
## 概要

pnpm v11 へのアップデートに伴い、ビルドスクリプトのデフォルトブロック機能への対応を行います。

## 変更内容

pnpm v11 では、セキュリティ向上のためパッケージのビルドスクリプトがデフォルトでブロックされるようになりました。これにより以下のエラーが発生します:

- `[ERR_PNPM_IGNORED_BUILDS]`: `pnpm install` でビルドスクリプトがブロックされる
- `[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY]`: Docker ビルド時の非 TTY 環境でモジュールディレクトリ削除の確認が発生

### 修正

1. `pnpm-workspace.yaml` に `allowBuilds: esbuild: true` を追加し、esbuild のビルドスクリプトを明示的に許可
2. `pnpm-workspace.yaml` に `confirmModulesPurge: false` を追加し、非 TTY 環境でのモジュール削除確認プロンプトを抑制
3. Dockerfile の COPY に `pnpm-workspace.yaml` を追加し、`pnpm fetch` / `pnpm install` 時に設定が反映されるよう対応

### 備考

- `nodeLinker: hoisted` は #466 で isolated モード（pnpm デフォルト）への移行が完了済みのため含めない
- Dockerfile の `RUN pnpm config set node-linker hoisted` 削除・COPY 再構成は #466 で対応済み

## 関連

- book000/book000#108
- #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)