### PR TITLE
fix: node-linker=hoisted を撤廃して pnpm デフォルト (isolated) に移行

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,10 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-RUN pnpm config set node-linker hoisted
-
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json tsconfig.json ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 
-COPY package.json tsconfig.json .npmrc ./
 COPY src src
 COPY entrypoint.sh ./
 


### PR DESCRIPTION
## 概要

Issue #464「なんで pnpm config set node-linker hoisted にしているのか確認」への対応。

### 変更内容

- **`.npmrc` 削除**: `node-linker=hoisted` の設定を撤廃し、pnpm デフォルト (isolated) に移行
- **Dockerfile から `RUN pnpm config set node-linker hoisted` を削除**:
  - pnpm v11 でこのコマンドはグローバル設定として非サポートになり (`ERR_PNPM_CONFIG_SET_UNSUPPORTED_YAML_CONFIG_KEY`)、Docker build が既にビルド失敗していた
- **`COPY package.json tsconfig.json ./` を `pnpm fetch` の前に移動**:
  - 従来: `pnpm fetch` (package.json がなく corepack が pnpm v11 を DL) → `pnpm install` (package.json 有りで corepack が pnpm v10 を DL) というバージョン不整合が発生
  - 修正後: `package.json` を先にコピーすることで corepack が `packageManager: pnpm@10.33.x` を読み取り、両コマンドで同一バージョンを使用

### 調査結果

`node-linker=hoisted` は PR #385 (v3 release) での Yarn → pnpm 移行時に防御的に選択されたものの:
- cycletls の Go バイナリ解決 (`__dirname` 利用) は isolated モードでも Node.js が realpath を解決するため問題なし
- Docker ビルドで確認済み: `node_modules/cycletls` → シンボリンク (isolated)、Go バイナリに実行属性あり (`-rwxr-xr-x`)

### 検証

- `pnpm lint` / `pnpm lint:tsc` パス
- `docker build` 成功
- Docker イメージ内で cycletls のシンボリンク構造と Go バイナリの実行属性を確認

## テスト計画

- [ ] GitHub Actions CI の成功を確認
- [ ] Docker ビルドが成功すること
- [ ] cycletls を経由した Twitter API リクエストが機能すること (実環境での動作確認)

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)