### PR TITLE
fix: twitter-openapi-typescript v0.0.56 の API 構造変更に対応

### DIFF
--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -27,9 +27,12 @@ export function normalizeUserSnapshot(data: unknown): UserSnapshot | null {
         protected?: boolean
       }
     | undefined
+  // v0.0.56 以降、 screen_name / name は legacy から core に移動した
+  const core = user.core as { screenName?: string; name?: string } | undefined
 
-  const screenName = legacy?.screenName ?? legacy?.screen_name
-  const name = legacy?.name ?? ''
+  const screenName =
+    legacy?.screenName ?? legacy?.screen_name ?? core?.screenName
+  const name = legacy?.name ?? core?.name ?? ''
 
   if (!restId || !screenName) {
     return null


### PR DESCRIPTION
## 概要

`twitter-openapi-typescript` v0.0.56 で `UserByScreenName` の `queryId` が変更され、API レスポンスの `screen_name` / `name` フィールドが `legacy` から `core` に移動した問題を修正します。

## 変更内容

### `src/core/normalize.ts`

`normalizeUserSnapshot` 関数において、`user.core` フィールドを `screenName` / `name` のフォールバックとして参照するよう修正しました。

**変更前:**
```ts
const screenName = legacy?.screenName ?? legacy?.screen_name
const name = legacy?.name ?? ''
```

**変更後:**
```ts
// v0.0.56 以降、 screen_name / name は legacy から core に移動した
const core = user.core as { screenName?: string; name?: string } | undefined

const screenName =
  legacy?.screenName ?? legacy?.screen_name ?? core?.screenName
const name = legacy?.name ?? core?.name ?? ''
```

## 原因

v0.0.56 で `queryId` が `1VOOyvKkiI3FMmkeDNxM9A` → `IGgvgiOx4QZndDHuD3x9TQ` に変更され、新しい queryId では `screen_name` / `name` が `legacy` ではなく `core` に格納されるようになりました。

旧実装は `legacy` のみを参照していたため、新構造では `screenName` が `undefined` となり、`null` を返すようになっていました（→ "Failed to resolve user" エラー）。

## テスト

- `pnpm lint` / `pnpm lint:tsc` 通過確認済み

- Closes #511