### PR TITLE
fix: TypeScript v6 の非推奨設定を削除して永続的な修正を適用

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,11 +23,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
+    "types": ["node"],
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v7 では `ignoreDeprecations: "6.0"` のサポートが廃止されるため、該当設定を削除し永続的な修正を適用します。

Fixes #525

## 変更内容

- `tsconfig.json` から `ignoreDeprecations: "6.0"` を削除
- `tsconfig.json` から `baseUrl: "."` を削除
- `paths` のエイリアスを `"@/*": ["src/*"]` から `"@/*": ["./src/*"]` に変更（tsconfig ファイルからの相対パスに統一）
- `types: ["node"]` を追加（TypeScript 6.0 で廃止された `@types/node` の自動読み込みを明示的な指定で代替）

## 動作確認

- `pnpm install` 正常完了
- `tsc --noEmit` 型エラーなし
- `pnpm lint` 全チェック通過