### PR TITLE
fix: eslint-plugin-unicorn の新ルール指摘を修正

### DIFF
--- a/src/app/fetch-users.ts
+++ b/src/app/fetch-users.ts
@@ -3,6 +3,31 @@ import { withRetry } from '../core/retry.js'
 import { type UserSnapshot } from '../core/types.js'
 
 /**
+ * 1ページ分のアイテムを正規化し、未取得のユーザーのみ追加する。
+ * @param items 1ページ分の生アイテム一覧。
+ * @param users 追記先のユーザー一覧。
+ * @param seen 取得済みユーザー ID の集合。
+ * @returns このページで追加した件数。
+ */
+function addUniqueUsers(
+  items: unknown[],
+  users: UserSnapshot[],
+  seen: Set<string>
+): number {
+  let pageAdded = 0
+  for (const item of items) {
+    const snapshot = normalizeUserSnapshot(item)
+    if (!snapshot || seen.has(snapshot.id)) {
+      continue
+    }
+    seen.add(snapshot.id)
+    users.push(snapshot)
+    pageAdded += 1
+  }
+  return pageAdded
+}
+
+/**
  * カーソルを辿って全ページ取得する。
  * @param label ログ用ラベル。
  * @param fetchPage 1ページ取得関数。
@@ -30,19 +55,7 @@ export async function fetchAllUsers(
       operationName: `${label} page ${page}`,
     })
 
-    let pageAdded = 0
-    for (const item of response.data.data) {
-      const snapshot = normalizeUserSnapshot(item)
-      if (!snapshot) {
-        continue
-      }
-      if (seen.has(snapshot.id)) {
-        continue
-      }
-      seen.add(snapshot.id)
-      users.push(snapshot)
-      pageAdded += 1
-    }
+    const pageAdded = addUniqueUsers(response.data.data, users, seen)
 
     const nextCursor = response.data.cursor.bottom?.value
     console.log(

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -11,12 +11,12 @@ export function diffUsers(
   previous: UserSnapshot[] | undefined,
   current: UserSnapshot[]
 ): { added: UserSnapshot[]; removed: UserSnapshot[] } {
-  const prevMap = new Map((previous ?? []).map((user) => [user.id, user]))
-  const currMap = new Map(current.map((user) => [user.id, user]))
+  const previousMap = new Map((previous ?? []).map((user) => [user.id, user]))
+  const currentMap = new Map(current.map((user) => [user.id, user]))
 
-  const added = sortUsers(current.filter((user) => !prevMap.has(user.id)))
+  const added = sortUsers(current.filter((user) => !previousMap.has(user.id)))
   const removed = sortUsers(
-    (previous ?? []).filter((user) => !currMap.has(user.id))
+    (previous ?? []).filter((user) => !currentMap.has(user.id))
   )
 
   return { added, removed }

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -32,11 +32,11 @@ export function normalizeUserSnapshot(data: unknown): UserSnapshot | null {
 
   const screenName =
     legacy?.screenName ?? legacy?.screen_name ?? core?.screenName
-  const name = legacy?.name ?? core?.name ?? ''
 
   if (!restId || !screenName) {
     return null
   }
+  const name = legacy?.name ?? core?.name ?? ''
 
   return {
     id: restId,

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -4,8 +4,8 @@
  * @returns 待機ミリ秒。判定できない場合は null。
  */
 export function getRateLimitDelayMs(error: unknown): number | null {
-  const err = error as { response?: Response; message?: string }
-  const response = err.response
+  const error_ = error as { response?: Response; message?: string }
+  const response = error_.response
   if (response?.status !== 429) {
     return null
   }
@@ -25,8 +25,8 @@ export function getRateLimitDelayMs(error: unknown): number | null {
       return waitMs + 2000
     }
   }
-  if (err.message) {
-    console.warn(`Rate limit hit: ${err.message}`)
+  if (error_.message) {
+    console.warn(`Rate limit hit: ${error_.message}`)
   }
   return 30_000
 }
@@ -34,12 +34,12 @@ export function getRateLimitDelayMs(error: unknown): number | null {
 /**
  * 指数バックオフ付きの汎用リトライ。
  * @typeParam T 返却型。
- * @param fn 実行する関数。
+ * @param function_ 実行する関数。
  * @param options リトライ設定。
  * @returns 成功時の戻り値。
  */
 export async function withRetry<T>(
-  fn: () => Promise<T>,
+  function_: () => Promise<T>,
   options: {
     maxRetries?: number
     baseDelayMs?: number
@@ -56,7 +56,7 @@ export async function withRetry<T>(
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      return await fn()
+      return await function_()
     } catch (error: unknown) {
       if (attempt >= maxRetries) {
         throw error

--- a/src/infra/auth.ts
+++ b/src/infra/auth.ts
@@ -29,11 +29,11 @@ function isValidCachedCookies(data: unknown): data is CachedCookies {
   if (typeof data !== 'object' || data === null) {
     return false
   }
-  const obj = data as Record<string, unknown>
+  const object = data as Record<string, unknown>
   return (
-    typeof obj.auth_token === 'string' &&
-    typeof obj.ct0 === 'string' &&
-    typeof obj.savedAt === 'number'
+    typeof object.auth_token === 'string' &&
+    typeof object.ct0 === 'string' &&
+    typeof object.savedAt === 'number'
   )
 }
 
@@ -68,9 +68,9 @@ function loadCachedCookies(): CachedCookies | null {
  * @param ct0 ct0 の値。
  */
 function saveCookies(authToken: string, ct0: string): void {
-  const dir = path.dirname(COOKIE_CACHE_FILE)
-  if (dir && dir !== '.' && !fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true })
+  const directory = path.dirname(COOKIE_CACHE_FILE)
+  if (directory && directory !== '.' && !fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true })
   }
   const data: CachedCookies = {
     auth_token: authToken,

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -100,31 +100,30 @@ export function loadConfig(): AppConfig {
  * @returns 認証情報。
  */
 export function getCredentials(): Credentials {
-  const envUsername = process.env.TWITTER_USERNAME
-  const envPassword = process.env.TWITTER_PASSWORD
-  const envEmail = process.env.TWITTER_EMAIL_ADDRESS
-  const envTwoFactor = process.env.TWITTER_AUTH_CODE_SECRET
+  const environmentUsername = process.env.TWITTER_USERNAME
+  const environmentPassword = process.env.TWITTER_PASSWORD
+  const environmentEmail = process.env.TWITTER_EMAIL_ADDRESS
+  const environmentTwoFactor = process.env.TWITTER_AUTH_CODE_SECRET
 
-  let config: AppConfig | null = null
-  if (!envUsername || !envPassword) {
-    config = loadConfig()
-  } else if (!envEmail && fs.existsSync(CONFIG_PATH)) {
-    config = loadConfig()
-  }
+  const requiresConfig =
+    !environmentUsername ||
+    !environmentPassword ||
+    (!environmentEmail && fs.existsSync(CONFIG_PATH))
+  const config: AppConfig | null = requiresConfig ? loadConfig() : null
 
-  const username = envUsername ?? config?.twitter.username
-  const password = envPassword ?? config?.twitter.password
-  const emailAddress = envEmail ?? config?.twitter.emailAddress
+  const username = environmentUsername ?? config?.twitter.username
+  const password = environmentPassword ?? config?.twitter.password
 
   if (!username || !password) {
     throw new Error('TWITTER_USERNAME or TWITTER_PASSWORD is not set')
   }
+  const emailAddress = environmentEmail ?? config?.twitter.emailAddress
 
   return {
     username,
     password,
     emailAddress,
-    twoFactorSecret: envTwoFactor,
+    twoFactorSecret: environmentTwoFactor,
   }
 }
 

--- a/src/infra/cycletls.ts
+++ b/src/infra/cycletls.ts
@@ -12,15 +12,17 @@ interface HeadersLike {
   [Symbol.iterator]?: () => Iterator<[string, string]>
 }
 
-let cycleTLSInstancePromise: Promise<CycleTLSClient> | null = null
+const cycleTLSState: { instancePromise: Promise<CycleTLSClient> | null } = {
+  instancePromise: null,
+}
 
 /**
  * CycleTLS インスタンスを初期化し、共有する。
  * @returns CycleTLS クライアント。
  */
 async function initCycleTLSWithProxy(): Promise<CycleTLSClient> {
-  cycleTLSInstancePromise ??= initCycleTLS()
-  return cycleTLSInstancePromise
+  cycleTLSState.instancePromise ??= initCycleTLS()
+  return cycleTLSState.instancePromise
 }
 
 /**
@@ -38,7 +40,7 @@ export async function cycleTLSFetchWithProxy(
     typeof input === 'string'
       ? input
       : input instanceof URL
-        ? input.toString()
+        ? input.href
         : input.url
 
   const method = (init?.method ?? 'GET').toUpperCase()
@@ -54,7 +56,7 @@ export async function cycleTLSFetchWithProxy(
       for (const [key, value] of init.headers) {
         headers[key] = value
       }
-    } else if (h[Symbol.iterator] && typeof h[Symbol.iterator] === 'function') {
+    } else if (typeof h[Symbol.iterator] === 'function') {
       for (const [key, value] of init.headers as unknown as Iterable<
         [string, string]
       >) {
@@ -91,7 +93,7 @@ export async function cycleTLSFetchWithProxy(
         const proxyUrl = new URL(normalizedProxyServer)
         proxyUrl.username = proxyUsername
         proxyUrl.password = proxyPassword
-        proxy = proxyUrl.toString()
+        proxy = proxyUrl.href
       } catch {
         throw new Error(
           `Invalid PROXY_SERVER URL: ${proxyServer}. Expected format: host:port, http://host:port or https://host:port`
@@ -162,9 +164,9 @@ export async function cycleTLSFetchWithProxy(
  * @returns なし。
  */
 export async function cleanupCycleTLS(): Promise<void> {
-  if (cycleTLSInstancePromise) {
+  if (cycleTLSState.instancePromise) {
     try {
-      const instance = await cycleTLSInstancePromise
+      const instance = await cycleTLSState.instancePromise
       await instance.exit()
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'

--- a/src/infra/fs.ts
+++ b/src/infra/fs.ts
@@ -24,9 +24,9 @@ export function readJsonFile(filePath: string): unknown {
  * @param data 書き込みデータ。
  */
 export function writeJsonFile(filePath: string, data: unknown): void {
-  const dir = path.dirname(filePath)
-  if (dir && dir !== '.' && !fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true })
+  const directory = path.dirname(filePath)
+  if (directory && directory !== '.' && !fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true })
   }
   fs.writeFileSync(filePath, JSON.stringify(data, null, 2))
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,11 +44,11 @@ function formatErrorDetails(error: unknown): string {
 function logFatalError(error: unknown): void {
   const errorDetails = formatErrorDetails(error)
   const timestamp = new Date().toISOString().replaceAll(':', '-')
-  const logDir = path.join(OUTPUT_DIR, 'logs')
-  const logPath = path.join(logDir, `fatal-error-${timestamp}.log`)
+  const logDirectory = path.join(OUTPUT_DIR, 'logs')
+  const logPath = path.join(logDirectory, `fatal-error-${timestamp}.log`)
 
   try {
-    fs.mkdirSync(logDir, { recursive: true })
+    fs.mkdirSync(logDirectory, { recursive: true })
     fs.writeFileSync(logPath, errorDetails, 'utf8')
     console.error(`Fatal error occurred. Details saved to ${logPath}`)
   } catch {
@@ -116,14 +116,14 @@ async function main(): Promise<void> {
       })
     )
 
-    const targetDir = path.join(
+    const targetDirectory = path.join(
       OUTPUT_DIR,
       targetUsername.replaceAll(/[^a-zA-Z0-9_-]/g, '_')
     )
 
-    const followersPath = path.join(targetDir, 'followers.json')
-    const followingPath = path.join(targetDir, 'following.json')
-    const diffPath = path.join(targetDir, 'diff.json')
+    const followersPath = path.join(targetDirectory, 'followers.json')
+    const followingPath = path.join(targetDirectory, 'following.json')
+    const diffPath = path.join(targetDirectory, 'diff.json')
 
     const previousFollowers = readJsonFile(followersPath) as SnapshotFile | null
     const previousFollowing = readJsonFile(followingPath) as SnapshotFile | null
@@ -208,7 +208,11 @@ async function main(): Promise<void> {
   process.exitCode = exitCode
 }
 
-main().catch((error: unknown) => {
-  logFatalError(error)
-  process.exitCode = 1
-})
+;(async () => {
+  try {
+    await main()
+  } catch (error) {
+    logFatalError(error)
+    process.exitCode = 1
+  }
+})()

--- a/src/presentation/discord.ts
+++ b/src/presentation/discord.ts
@@ -8,17 +8,17 @@ import { type UserSnapshot } from '../core/types.js'
  */
 /**
  * Discord 用の Embed を組み立てる。
- * @param params パラメータ。
+ * @param parameters パラメータ。
  * @returns Embed オブジェクト。
  */
-function buildDiscordEmbed(params: {
+function buildDiscordEmbed(parameters: {
   title: string
   diff: { added: UserSnapshot[]; removed: UserSnapshot[] }
   targetUsername: string
   checkedAt: string
 }): Record<string, unknown> {
-  const addedCount = params.diff.added.length
-  const removedCount = params.diff.removed.length
+  const addedCount = parameters.diff.added.length
+  const removedCount = parameters.diff.removed.length
   const total = addedCount + removedCount
 
   const formatUsers = (users: UserSnapshot[]): string => {
@@ -34,11 +34,11 @@ function buildDiscordEmbed(params: {
       .join(', ')
   }
 
-  const addedText = formatUsers(params.diff.added)
-  const removedText = formatUsers(params.diff.removed)
+  const addedText = formatUsers(parameters.diff.added)
+  const removedText = formatUsers(parameters.diff.removed)
 
   return {
-    title: `${params.title === 'フォロワー' ? '👥' : '🔔'} ${params.title}`,
+    title: `${parameters.title === 'フォロワー' ? '👥' : '🔔'} ${parameters.title}`,
     color: 0x1d_a1_f2,
     fields: [
       {
@@ -53,9 +53,9 @@ function buildDiscordEmbed(params: {
       },
     ],
     footer: {
-      text: `チェック対象ユーザー: @${params.targetUsername}`,
+      text: `チェック対象ユーザー: @${parameters.targetUsername}`,
     },
-    timestamp: params.checkedAt,
+    timestamp: parameters.checkedAt,
   }
 }
 
@@ -111,7 +111,12 @@ export async function sendDiscordNotification(
   })
 
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
+    let text = ''
+    try {
+      text = await response.text()
+    } catch {
+      // レスポンスボディが読めなくてもログ出力自体は継続する
+    }
     console.warn(
       `Discord webhook failed: ${response.status} ${response.statusText} ${text}`.trim()
     )


### PR DESCRIPTION
## 概要

`@book000/eslint-config` が既に `master` 上で 1.15.44 に更新されており、これに伴って `eslint-plugin-unicorn` も v71.1.0 に上がったため、新規/強化されたルールが既存コードの25箇所を指摘して `lint:eslint` が失敗していました（Renovate PR #567 の `@types/node` バンプ自体とは無関係な、既存コードの問題です）。

## 対応内容

- `unicorn/name-replacements`: 変数名の改善（`dir`→`directory`、`obj`→`object`、`params`→`parameters` 等）
- `unicorn/prefer-await`: `.catch()` チェーンを `try`/`await` に置き換え
- `unicorn/no-break-in-nested-loop`: ネストループ内の `continue` をヘルパー関数に抽出
- `unicorn/no-declarations-before-early-exit`: 宣言を early exit の後に移動
- `unicorn/no-duplicate-if-branches`: 同一処理を行う if/else 分岐を条件式に統合
- `unicorn/no-top-level-assignment-in-function`: モジュールレベル変数への関数内代入をオブジェクトのプロパティ経由に変更
- `unicorn/prefer-url-href`: `URL#toString()` を `URL#href` に置き換え
- `unicorn/no-computed-property-existence-check`: 冗長な存在チェックを削除

挙動は変更していません。`package.json` / `pnpm-lock.yaml` はこの PR では変更していません（依存バージョンの更新自体は Renovate PR #567 の役割のままです）。

## 動作確認

- `pnpm run lint:eslint` / `pnpm run lint:prettier` / `pnpm run lint:tsc` すべてパス

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)