### PR TITLE
feat: GlitchTip でエラー送信を実装する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ X (Twitter) のフォロー・フォロワーの変更を監視し、差分を�
 ## 重点的に確認する点
 
 - **機密情報の混入**: API キー・パスワード・認証トークン・Discord Webhook URL・Cookie が、コード・ログ出力・コミット差分に含まれていないか。認証情報は `config.json`（`data/` 配下）または環境変数で管理される。
-- **エラーハンドリング**: 非公式 API・ネットワーク・認証は失敗しうる。例外の握り潰しがないか、致命的エラーが `src/main.ts` の `logFatalError` 経由で扱われているか。
+- **エラーハンドリング**: 非公式 API・ネットワーク・認証は失敗しうる。例外の握り潰しがないか、致命的エラーが `src/main.ts` の最上位 catch 節で `@book000/node-utils` の `Logger` を用いた `logger.error(...)` 経由で扱われているか、`SENTRY_DSN` 環境変数が設定されている場合に GlitchTip へ自動送信される構成になっているか。
 - **設定値のハードコード**: パスや出力先は環境変数（`CONFIG_PATH` / `OUTPUT_DIR` / `COOKIE_CACHE_PATH`）で上書き可能な設計。新しい設定はハードコードせず `src/infra/config.ts` のパターンに従っているか。
 - **ドキュメント同期**: 新しい設定項目の追加時に `config.sample.json` と `src/infra/config.ts` の型定義が更新されているか。
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 data/
+logs/
 .DS_Store
 *.log
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@
 - **Node.js**: `.node-version` (v24.18.0) に従う
 
 ## コード改修時のルール
-- **エラーメッセージ**: 絵文字の使用はプロジェクトの既存スタイルに合わせる（現状は標準的なテキストログ）。致命的なエラーは `src/main.ts` の `logFatalError` を使用してファイル出力する。
+- **エラーメッセージ**: 絵文字の使用はプロジェクトの既存スタイルに合わせる（現状は標準的なテキストログ）。ログ出力は `@book000/node-utils` の `Logger`（`Logger.configure('<category>')`）経由で行う。致命的なエラーは `src/main.ts` の最上位 catch 節で `logger.error(...)` を使用し、`SENTRY_DSN` 環境変数が設定されている場合は GlitchTip へ自動送信される。
 - **TypeScript**: `tsconfig.json` は `strict: true`（`noImplicitAny` / `strictNullChecks` / `noUnusedLocals` / `noUnusedParameters` など）を有効化している。`any` や型エラーの握り潰しに頼らず、型定義を正しく行う。
 - **ドキュメント**: 関数やクラスには日本語で JSDoc を記載する。
 
@@ -58,7 +58,7 @@ pnpm lint:tsc
 ```
 
 ## アーキテクチャと主要ファイル
-- **`src/main.ts`**: エントリーポイント。全体のフロー制御と `logFatalError`。
+- **`src/main.ts`**: エントリーポイント。全体のフロー制御。
 - **`src/app/fetch-users.ts`**: ユーザーリスト取得ロジック。
 - **`src/core/diff.ts`**: フォロー・フォロワーの差分計算。`src/core/` には他に `normalize.ts` / `retry.ts` / `types.ts` がある。
 - **`src/infra/auth.ts`**: X (Twitter) へのログイン・認証ロジック。
@@ -71,6 +71,7 @@ pnpm lint:tsc
 - **HTTP リクエスト**: `twitter-openapi-typescript`・`@the-convocation/twitter-scraper`・`cycletls` を組み合わせて使用している。直接 `fetch` を使わず、ラップされたクライアントを使用すること。
 - **設定管理**: 環境変数と設定ファイル (`config.json`) の両方をサポートする `src/infra/config.ts` のパターンに従う。設定パスやデータ出力先はすべて環境変数で上書き可能: `CONFIG_PATH`（デフォルト `./data/config.json`）、`OUTPUT_DIR`（デフォルト `./data`）、`COOKIE_CACHE_PATH`（デフォルト `./data/twitter-cookies.json`）。新しい設定項目を追加する際はハードコードせずこのパターンに従う。
 - **データ出力**: スナップショットと差分は `<OUTPUT_DIR>/<targetUsername>/{followers.json,following.json,diff.json}` に保存される。`data/` はコミット対象外（`.gitignore` 済み）。
+- **ログ出力**: `console.*` を直接使わず、各ファイル冒頭で `Logger.configure('<category>')`（`@book000/node-utils`）により生成したロガー経由で出力する。
 
 ## セキュリティ / 機密情報
 - API キー・パスワード・認証トークン・Discord Webhook URL などの機密情報は絶対に Git にコミットしない。認証情報は `config.json`（`data/` 配下）または環境変数で管理する。

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,6 @@ ENV NODE_ENV=production
 ENV CONFIG_PATH=/data/config.json
 ENV OUTPUT_DIR=/data
 ENV COOKIE_CACHE_PATH=/data/twitter-cookies.json
+ENV LOG_DIR=/data/logs
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Optional:
 - `PROXY_SERVER` (format: `host:port` or `http(s)://host:port`)
 - `PROXY_USERNAME`
 - `PROXY_PASSWORD`
+- `LOG_DIR` (default: `logs`; log file output directory, provided by `@book000/node-utils`)
+- `LOG_LEVEL` (default: `info`; minimum level for console output)
+- `LOG_FILE_LEVEL` (default: `info`; minimum level for file output)
+- `SENTRY_DSN` (unset by default; when set, error/warn logs are automatically forwarded to GlitchTip)
+- `SENTRY_LOG_LEVEL` (default: `warn`; minimum level forwarded to GlitchTip)
+
+These logging-related variables are not set within this repository (e.g. in `docker-compose.yml`); set them on the host/runtime environment if needed.
 
 ## Output
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Optional:
 - `SENTRY_DSN` (unset by default; when set, error/warn logs are automatically forwarded to GlitchTip)
 - `SENTRY_LOG_LEVEL` (default: `warn`; minimum level forwarded to GlitchTip)
 
-These logging-related variables are not set within this repository (e.g. in `docker-compose.yml`); set them on the host/runtime environment if needed.
+`LOG_DIR` is set to `/data/logs` in the Dockerfile so log files persist under the container's mounted data volume by default. The other logging-related variables above are not set within this repository; set them on the host/runtime environment if needed.
 
 ## Output
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/tomacheese/watch-follow-follower/issues"
   },
   "dependencies": {
+    "@book000/node-utils": "1.25.8",
     "@the-convocation/twitter-scraper": "0.22.3",
     "cycletls": "2.0.5",
     "headers-polyfill": "5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@book000/node-utils':
+        specifier: 1.25.8
+        version: 1.25.8(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
       '@the-convocation/twitter-scraper':
         specifier: 0.22.3
         version: 0.22.3(cycletls@2.0.5)
@@ -48,10 +51,31 @@ importers:
 
 packages:
 
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.2':
+    resolution: {integrity: sha512-GvpKWDmzBFzbtVElU+tEDMDYyMY8SnMH4NNwwlUQioNHZvE6sSuHEqNkfU3iYhWL+/XO5Ej+MzhVJoqM10NYCQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
+
   '@book000/eslint-config@1.16.17':
     resolution: {integrity: sha512-DOET4gbanO7+E3GZ0r7nXZTmtFbeld0z/n2JpPLuEL3ukPswIU0nQynpiw+IFHySA+7RlIDS9qtxCF/YB1Q06A==}
     peerDependencies:
       eslint: 10.7.0
+
+  '@book000/node-utils@1.25.8':
+    resolution: {integrity: sha512-36ZZhffKtuA4FL4Hk0gMJIuuUNsVafSL1qGEhFOUSAVRJFqOEHxjrvo64UE43IwKatkNm9u6g/2wx24fZq5Xhw==}
+
+  '@colors/colors@1.6.0':
+    resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
+    engines: {node: '>=0.1.90'}
+
+  '@dabh/diagnostics@2.0.8':
+    resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -266,12 +290,105 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.67.0':
+    resolution: {integrity: sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.67.0':
+    resolution: {integrity: sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.67.0':
+    resolution: {integrity: sha512-SFKpZGqOCEFSmP93NdDP6ikZp4NS7A/JR8+2ofK3jF6Y9Vyox7pX0pxdOnPLpFcPtMybMahfWqSAWJvsFs4RmA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.67.0':
+    resolution: {integrity: sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/server-utils@10.67.0':
+    resolution: {integrity: sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==}
+    engines: {node: '>=18'}
+
   '@sinclair/typebox@0.32.35':
     resolution: {integrity: sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA==}
+
+  '@so-ric/colorspace@1.1.6':
+    resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
   '@stylistic/eslint-plugin@2.11.0':
     resolution: {integrity: sha512-PNRHbydNG5EH8NK4c+izdJlxajIR6GxcUhzsYNRsn6Myep4dsZt0qFCz3rCPnkvgO5FYibDcMqgNHUT+zvjYZw==}
@@ -308,6 +425,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/triple-beam@1.3.5':
+    resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
 
   '@typescript-eslint/eslint-plugin@8.64.0':
     resolution: {integrity: sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==}
@@ -480,9 +600,16 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -548,12 +675,31 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   cli-spinners@3.4.0:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
 
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
+
+  color-convert@3.1.3:
+    resolution: {integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==}
+    engines: {node: '>=14.6'}
+
+  color-name@2.1.1:
+    resolution: {integrity: sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==}
+    engines: {node: '>=12.20'}
+
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
+
+  color@5.0.3:
+    resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
     engines: {node: '>=18'}
 
   combined-stream@1.0.8:
@@ -586,6 +732,10 @@ packages:
 
   cssom@0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+
+  cycle@1.0.3:
+    resolution: {integrity: sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==}
+    engines: {node: '>=0.4.0'}
 
   cycletls@2.0.5:
     resolution: {integrity: sha512-Nud94JBPZu1JTXWJ1GpIoQNR1xxU84WYt7G0dxzwpUe1xAAs6YbihvlQhIhPv9xljjonINJfWPFaeb8Ex1wLhQ==}
@@ -658,6 +808,9 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
+  enabled@2.0.0:
+    resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
+
   enhanced-resolve@5.24.1:
     resolution: {integrity: sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==}
     engines: {node: '>=10.13.0'}
@@ -693,6 +846,9 @@ packages:
   es-iterator-helpers@1.3.3:
     resolution: {integrity: sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -833,9 +989,15 @@ packages:
       picomatch:
         optional: true
 
+  fecha@4.2.3:
+    resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-stream-rotator@0.6.1:
+    resolution: {integrity: sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==}
 
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
@@ -855,6 +1017,9 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  fn.name@1.1.0:
+    resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -983,6 +1148,10 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  import-in-the-middle@3.3.2:
+    resolution: {integrity: sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==}
+    engines: {node: '>=18'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -990,6 +1159,9 @@ packages:
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -1083,6 +1255,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -1142,6 +1318,9 @@ packages:
     resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
     engines: {node: '>= 0.4'}
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
@@ -1151,6 +1330,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kuler@2.0.0:
+    resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1177,9 +1359,16 @@ packages:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
 
+  logform@2.7.0:
+    resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
+    engines: {node: '>= 12.0.0'}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
@@ -1191,6 +1380,10 @@ packages:
 
   mdn-data@2.28.1:
     resolution: {integrity: sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==}
+
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1206,6 +1399,15 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  moment-timezone@0.6.3:
+    resolution: {integrity: sha512-pVEPA/HCFHHbwJ130ywnzYuZpkEGcP6Daa/OwNebpA18MybeFHmQilAGGovXgWijQ8vQtmud9jZrziUBgsykfg==}
+
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1251,6 +1453,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -1274,6 +1480,9 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  one-time@1.0.0:
+    resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1373,6 +1582,10 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -1384,6 +1597,10 @@ packages:
   regjsparser@0.13.2:
     resolution: {integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==}
     hasBin: true
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -1409,6 +1626,9 @@ packages:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -1416,6 +1636,13 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1480,6 +1707,13 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  stack-trace@0.0.10:
+    resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -1507,6 +1741,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
@@ -1527,6 +1764,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  text-hex@1.0.0:
+    resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
+
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
@@ -1545,6 +1785,10 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  triple-beam@1.4.1:
+    resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
+    engines: {node: '>= 14.0.0'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1647,6 +1891,9 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
@@ -1676,6 +1923,20 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  winston-daily-rotate-file@5.0.0:
+    resolution: {integrity: sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      winston: ^3
+
+  winston-transport@4.9.0:
+    resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
+    engines: {node: '>= 12.0.0'}
+
+  winston@3.19.0:
+    resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
+    engines: {node: '>= 12.0.0'}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -1718,6 +1979,30 @@ packages:
 
 snapshots:
 
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.2':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      es-module-lexer: 2.3.1
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@book000/eslint-config@1.16.17(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/parser': 8.65.0(eslint@10.7.0)(typescript@6.0.3)
@@ -1730,6 +2015,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@book000/node-utils@1.25.8(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/node': 10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      cycle: 1.0.3
+      jsonc-parser: 3.3.1
+      moment-timezone: 0.6.3
+      winston: 3.19.0
+      winston-daily-rotate-file: 5.0.0(winston@3.19.0)
+      winston-transport: 4.9.0
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@colors/colors@1.6.0': {}
+
+  '@dabh/diagnostics@2.0.8':
+    dependencies:
+      '@so-ric/colorspace': 1.1.6
+      enabled: 2.0.0
+      kuler: 2.0.0
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -1862,9 +2169,110 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@noble/hashes@2.2.0': {}
 
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.2
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.67.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/node-core@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/node-core': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.67.0
+      import-in-the-middle: 3.3.2
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+
+  '@sentry/server-utils@10.67.0':
+    dependencies:
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.2
+      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@sinclair/typebox@0.32.35': {}
+
+  '@so-ric/colorspace@1.1.6':
+    dependencies:
+      color: 5.0.3
+      text-hex: 1.0.0
 
   '@stylistic/eslint-plugin@2.11.0(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
@@ -1917,6 +2325,8 @@ snapshots:
       '@types/node': 25.9.5
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/triple-beam@1.3.5': {}
 
   '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@6.0.3))(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
@@ -2178,7 +2588,11 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  astring@1.9.0: {}
+
   async-function@1.0.0: {}
+
+  async@3.2.6: {}
 
   asynckit@0.4.0: {}
 
@@ -2238,12 +2652,29 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  cjs-module-lexer@2.2.0: {}
+
   cli-spinners@3.4.0: {}
 
   cli-truncate@4.0.0:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
+
+  color-convert@3.1.3:
+    dependencies:
+      color-name: 2.1.1
+
+  color-name@2.1.1: {}
+
+  color-string@2.1.4:
+    dependencies:
+      color-name: 2.1.1
+
+  color@5.0.3:
+    dependencies:
+      color-convert: 3.1.3
+      color-string: 2.1.4
 
   combined-stream@1.0.8:
     dependencies:
@@ -2280,6 +2711,8 @@ snapshots:
   css-what@6.2.2: {}
 
   cssom@0.5.0: {}
+
+  cycle@1.0.3: {}
 
   cycletls@2.0.5:
     dependencies:
@@ -2361,6 +2794,8 @@ snapshots:
   electron-to-chromium@1.5.387: {}
 
   emoji-regex@10.6.0: {}
+
+  enabled@2.0.0: {}
 
   enhanced-resolve@5.24.1:
     dependencies:
@@ -2459,6 +2894,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -2681,9 +3118,15 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fecha@4.2.3: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-stream-rotator@0.6.1:
+    dependencies:
+      moment: 2.30.1
 
   find-up-simple@1.0.1: {}
 
@@ -2703,6 +3146,8 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  fn.name@1.1.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -2834,9 +3279,17 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  import-in-the-middle@3.3.2:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   indent-string@5.0.0: {}
+
+  inherits@2.0.4: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -2939,6 +3392,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@2.0.1: {}
+
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -2998,6 +3453,8 @@ snapshots:
       jsonify: 0.0.1
       object-keys: 1.1.1
 
+  jsonc-parser@3.3.1: {}
+
   jsonify@0.0.1: {}
 
   jsx-ast-utils@3.3.5:
@@ -3010,6 +3467,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kuler@2.0.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -3037,9 +3496,22 @@ snapshots:
       is-unicode-supported: 2.1.0
       yoctocolors: 2.1.2
 
+  logform@2.7.0:
+    dependencies:
+      '@colors/colors': 1.6.0
+      '@types/triple-beam': 1.3.5
+      fecha: 4.2.3
+      ms: 2.1.3
+      safe-stable-stringify: 2.5.0
+      triple-beam: 1.4.1
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-asynchronous@1.1.0:
     dependencies:
@@ -3050,6 +3522,8 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.28.1: {}
+
+  meriyah@6.1.4: {}
 
   mime-db@1.52.0: {}
 
@@ -3064,6 +3538,14 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.15
+
+  module-details-from-path@1.0.4: {}
+
+  moment-timezone@0.6.3:
+    dependencies:
+      moment: 2.30.1
+
+  moment@2.30.1: {}
 
   ms@2.1.3: {}
 
@@ -3114,6 +3596,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@3.0.0: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -3147,6 +3631,10 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
+
+  one-time@1.0.0:
+    dependencies:
+      fn.name: 1.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -3229,6 +3717,12 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -3252,6 +3746,13 @@ snapshots:
   regjsparser@0.13.2:
     dependencies:
       jsesc: 3.1.0
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   requires-port@1.0.0: {}
 
@@ -3291,6 +3792,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -3301,6 +3804,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safe-stable-stringify@2.5.0: {}
+
+  semifies@1.0.0: {}
 
   semver@6.3.1: {}
 
@@ -3375,6 +3882,10 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
+  stack-trace@0.0.10: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -3431,6 +3942,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
@@ -3446,6 +3961,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tapable@2.3.3: {}
+
+  text-hex@1.0.0: {}
 
   time-span@5.1.0:
     dependencies:
@@ -3466,6 +3983,8 @@ snapshots:
   tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
+
+  triple-beam@1.4.1: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -3586,6 +4105,8 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  util-deprecate@1.0.2: {}
+
   web-worker@1.5.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -3639,6 +4160,34 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  winston-daily-rotate-file@5.0.0(winston@3.19.0):
+    dependencies:
+      file-stream-rotator: 0.6.1
+      object-hash: 3.0.0
+      triple-beam: 1.4.1
+      winston: 3.19.0
+      winston-transport: 4.9.0
+
+  winston-transport@4.9.0:
+    dependencies:
+      logform: 2.7.0
+      readable-stream: 3.6.2
+      triple-beam: 1.4.1
+
+  winston@3.19.0:
+    dependencies:
+      '@colors/colors': 1.6.0
+      '@dabh/diagnostics': 2.0.8
+      async: 3.2.6
+      is-stream: 2.0.1
+      logform: 2.7.0
+      one-time: 1.0.0
+      readable-stream: 3.6.2
+      safe-stable-stringify: 2.5.0
+      stack-trace: 0.0.10
+      triple-beam: 1.4.1
+      winston-transport: 4.9.0
 
   word-wrap@1.2.5: {}
 

--- a/src/app/fetch-users.ts
+++ b/src/app/fetch-users.ts
@@ -1,6 +1,9 @@
 import { normalizeUserSnapshot, sortUsers } from '../core/normalize.js'
 import { withRetry } from '../core/retry.js'
 import { type UserSnapshot } from '../core/types.js'
+import { Logger } from '@book000/node-utils'
+
+const logger = Logger.configure('fetch-users')
 
 /**
  * カーソルを辿って全ページ取得する。
@@ -21,7 +24,7 @@ export async function fetchAllUsers(
   let emptyPageStreak = 0
   while (true) {
     page += 1
-    console.log(
+    logger.info(
       `${label} page ${page} fetching...${cursor ? ` cursor=${cursor}` : ''}`
     )
     const response = await withRetry(() => fetchPage(cursor), {
@@ -45,7 +48,7 @@ export async function fetchAllUsers(
     }
 
     const nextCursor = response.data.cursor.bottom?.value
-    console.log(
+    logger.info(
       `${label} page ${page} fetched: +${pageAdded} (total ${users.length})`
     )
     if (pageAdded === 0) {

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -1,3 +1,7 @@
+import { Logger } from '@book000/node-utils'
+
+const logger = Logger.configure('retry')
+
 /**
  * 429 の Rate Limit から待機時間を計算する。
  * @param error 例外。
@@ -19,14 +23,14 @@ export function getRateLimitDelayMs(error: unknown): number | null {
       const now = Date.now()
       const waitMs = Math.max(resetMs - now, 1000)
       const resetTime = new Date(resetMs).toISOString()
-      console.warn(
+      logger.info(
         `Rate limit hit (remaining ${remaining ?? 'unknown'}/${limit ?? 'unknown'}). Reset at ${resetTime}.`
       )
       return waitMs + 2000
     }
   }
   if (err.message) {
-    console.warn(`Rate limit hit: ${err.message}`)
+    logger.info(`Rate limit hit: ${err.message}`)
   }
   return 30_000
 }
@@ -67,11 +71,11 @@ export async function withRetry<T>(
         Math.min(baseDelayMs * Math.pow(2, attempt - 1), maxDelayMs)
       const delaySeconds = Math.ceil(delay / 1000)
       if (rateLimitDelay) {
-        console.warn(
+        logger.info(
           `${operationName} hit rate limit, retrying in ${delaySeconds}s...`
         )
       } else {
-        console.warn(
+        logger.info(
           `${operationName} failed (attempt ${attempt}/${maxRetries}), retrying in ${delaySeconds}s...`
         )
       }

--- a/src/infra/auth.ts
+++ b/src/infra/auth.ts
@@ -1,12 +1,24 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { Scraper } from '@the-convocation/twitter-scraper'
+import { Logger } from '@book000/node-utils'
 import { cycleTLSFetchWithProxy } from './cycletls.js'
 import {
   COOKIE_CACHE_FILE,
   COOKIE_EXPIRY_DAYS,
   type Credentials,
 } from './config.js'
+
+const logger = Logger.configure('auth')
+
+/**
+ * unknown な例外情報を Error に変換する。
+ * @param error - 例外情報。
+ * @returns Error インスタンス。
+ */
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
 
 /**
  * ディスクに保存する認証 Cookie キャッシュ。
@@ -48,7 +60,7 @@ function loadCachedCookies(): CachedCookies | null {
     }
     const data: unknown = JSON.parse(fs.readFileSync(COOKIE_CACHE_FILE, 'utf8'))
     if (!isValidCachedCookies(data)) {
-      console.warn('Invalid cookie cache structure')
+      logger.warn('Invalid cookie cache structure')
       return null
     }
     const expiryMs = COOKIE_EXPIRY_DAYS * 24 * 60 * 60 * 1000
@@ -57,7 +69,7 @@ function loadCachedCookies(): CachedCookies | null {
     }
     return data
   } catch (error) {
-    console.warn('Failed to load cached cookies', error)
+    logger.warn('Failed to load cached cookies', toError(error))
     return null
   }
 }
@@ -100,7 +112,7 @@ async function loginWithRetry(
 ): Promise<void> {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      console.log(`Login attempt ${attempt}/${maxRetries}...`)
+      logger.info(`Login attempt ${attempt}/${maxRetries}...`)
       await scraper.login(username, password, email, twoFactorSecret)
       return
     } catch (error: unknown) {
@@ -111,7 +123,7 @@ async function loginWithRetry(
 
       if (is503 && attempt < maxRetries) {
         const delay = Math.min(1000 * Math.pow(2, attempt - 1), 30_000)
-        console.warn(`503 error, retrying in ${delay / 1000}s...`)
+        logger.info(`503 error, retrying in ${delay / 1000}s...`)
         await new Promise((resolve) => setTimeout(resolve, delay))
       } else {
         throw error
@@ -130,11 +142,11 @@ export async function getAuthCookies(
 ): Promise<{ authToken: string; ct0: string }> {
   const cached = loadCachedCookies()
   if (cached) {
-    console.log('Using cached cookies')
+    logger.info('Using cached cookies')
     return { authToken: cached.auth_token, ct0: cached.ct0 }
   }
 
-  console.log('Logging in with twitter-scraper + CycleTLS...')
+  logger.info('Logging in with twitter-scraper + CycleTLS...')
   const scraper = new Scraper({
     fetch: cycleTLSFetchWithProxy,
   })
@@ -160,7 +172,7 @@ export async function getAuthCookies(
   }
 
   saveCookies(authToken, ct0)
-  console.log('Login successful, cookies saved')
+  logger.info('Login successful, cookies saved')
 
   return { authToken, ct0 }
 }

--- a/src/infra/auth.ts
+++ b/src/infra/auth.ts
@@ -12,12 +12,43 @@ import {
 const logger = Logger.configure('auth')
 
 /**
+ * GlitchTip へ転送されるログメッセージの最大文字数。
+ * サードパーティ API のエラーには HTTP レスポンスヘッダーやボディ全体が
+ * message に埋め込まれることがあるため、外部送信時の情報量を抑える。
+ */
+const MAX_ERROR_MESSAGE_LENGTH = 2000
+
+/**
+ * エラーメッセージが長すぎる場合に切り詰める。
+ * @param message - 元のメッセージ。
+ * @returns 切り詰め後のメッセージ。
+ */
+function truncateMessage(message: string): string {
+  if (message.length <= MAX_ERROR_MESSAGE_LENGTH) {
+    return message
+  }
+  return `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}... [truncated]`
+}
+
+/**
  * unknown な例外情報を Error に変換する。
+ * Error 以外の値は JSON.stringify で構造化情報を保持しつつ、
+ * シリアライズできない場合のみ String() にフォールバックする。
  * @param error - 例外情報。
  * @returns Error インスタンス。
  */
 function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error))
+  if (error instanceof Error) {
+    if (error.message.length <= MAX_ERROR_MESSAGE_LENGTH) {
+      return error
+    }
+    return new Error(truncateMessage(error.message))
+  }
+  try {
+    return new Error(truncateMessage(JSON.stringify(error)))
+  } catch {
+    return new Error(truncateMessage(String(error)))
+  }
 }
 
 /**

--- a/src/infra/cycletls.ts
+++ b/src/infra/cycletls.ts
@@ -6,12 +6,43 @@ import { Logger } from '@book000/node-utils'
 const logger = Logger.configure('cycletls')
 
 /**
+ * GlitchTip へ転送されるログメッセージの最大文字数。
+ * サードパーティ API のエラーには HTTP レスポンスヘッダーやボディ全体が
+ * message に埋め込まれることがあるため、外部送信時の情報量を抑える。
+ */
+const MAX_ERROR_MESSAGE_LENGTH = 2000
+
+/**
+ * エラーメッセージが長すぎる場合に切り詰める。
+ * @param message - 元のメッセージ。
+ * @returns 切り詰め後のメッセージ。
+ */
+function truncateMessage(message: string): string {
+  if (message.length <= MAX_ERROR_MESSAGE_LENGTH) {
+    return message
+  }
+  return `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}... [truncated]`
+}
+
+/**
  * unknown な例外情報を Error に変換する。
+ * Error 以外の値は JSON.stringify で構造化情報を保持しつつ、
+ * シリアライズできない場合のみ String() にフォールバックする。
  * @param error - 例外情報。
  * @returns Error インスタンス。
  */
 function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error))
+  if (error instanceof Error) {
+    if (error.message.length <= MAX_ERROR_MESSAGE_LENGTH) {
+      return error
+    }
+    return new Error(truncateMessage(error.message))
+  }
+  try {
+    return new Error(truncateMessage(JSON.stringify(error)))
+  } catch {
+    return new Error(truncateMessage(String(error)))
+  }
 }
 
 /**

--- a/src/infra/cycletls.ts
+++ b/src/infra/cycletls.ts
@@ -1,6 +1,18 @@
 import { cycleTLSExit } from '@the-convocation/twitter-scraper/cycletls'
 import initCycleTLS, { type CycleTLSClient } from 'cycletls'
 import { Headers } from 'headers-polyfill'
+import { Logger } from '@book000/node-utils'
+
+const logger = Logger.configure('cycletls')
+
+/**
+ * unknown な例外情報を Error に変換する。
+ * @param error - 例外情報。
+ * @returns Error インスタンス。
+ */
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
 
 /**
  * undici/Headers 互換の Headers 形状。
@@ -167,16 +179,15 @@ export async function cleanupCycleTLS(): Promise<void> {
       const instance = await cycleTLSInstancePromise
       await instance.exit()
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error'
-      console.warn(`CycleTLS instance exit failed: ${message}`)
+      logger.warn('CycleTLS instance exit failed', toError(error))
     }
   }
   try {
     cycleTLSExit()
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error'
-    console.debug(
-      `twitter-scraper CycleTLS exit error (may not be initialized): ${message}`
+    logger.debug(
+      'twitter-scraper CycleTLS exit error (may not be initialized)',
+      { message: toError(error).message }
     )
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,12 +20,43 @@ import { sendDiscordNotification } from './presentation/discord.js'
 const logger = Logger.configure('main')
 
 /**
+ * GlitchTip へ転送されるログメッセージの最大文字数。
+ * サードパーティ API のエラーには HTTP レスポンスヘッダーやボディ全体が
+ * message に埋め込まれることがあるため、外部送信時の情報量を抑える。
+ */
+const MAX_ERROR_MESSAGE_LENGTH = 2000
+
+/**
+ * エラーメッセージが長すぎる場合に切り詰める。
+ * @param message - 元のメッセージ。
+ * @returns 切り詰め後のメッセージ。
+ */
+function truncateMessage(message: string): string {
+  if (message.length <= MAX_ERROR_MESSAGE_LENGTH) {
+    return message
+  }
+  return `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}... [truncated]`
+}
+
+/**
  * unknown な例外情報を Error に変換する。
+ * Error 以外の値は JSON.stringify で構造化情報を保持しつつ、
+ * シリアライズできない場合のみ String() にフォールバックする。
  * @param error - 例外情報。
  * @returns Error インスタンス。
  */
 function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error))
+  if (error instanceof Error) {
+    if (error.message.length <= MAX_ERROR_MESSAGE_LENGTH) {
+      return error
+    }
+    return new Error(truncateMessage(error.message))
+  }
+  try {
+    return new Error(truncateMessage(JSON.stringify(error)))
+  } catch {
+    return new Error(truncateMessage(String(error)))
+  }
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
-import fs from 'node:fs'
 import path from 'node:path'
 import { TwitterOpenApi } from 'twitter-openapi-typescript'
+import { Logger } from '@book000/node-utils'
 import { diffUsers } from './core/diff.js'
 import { normalizeUserSnapshot } from './core/normalize.js'
 import { type DiffFile, type SnapshotFile } from './core/types.js'
@@ -17,44 +17,15 @@ import { getAuthCookies } from './infra/auth.js'
 import { withRetry } from './core/retry.js'
 import { sendDiscordNotification } from './presentation/discord.js'
 
-/**
- * エラー内容を文字列化する。
- * @param error - 例外情報。
- * @returns エラー内容の文字列。
- */
-function formatErrorDetails(error: unknown): string {
-  if (error instanceof Error) {
-    if (error.stack) {
-      return error.stack
-    }
-    return `${error.name}: ${error.message}`
-  }
-
-  try {
-    return JSON.stringify(error, null, 2)
-  } catch {
-    return String(error)
-  }
-}
+const logger = Logger.configure('main')
 
 /**
- * 致命的なエラーの詳細をファイルに出力する。
+ * unknown な例外情報を Error に変換する。
  * @param error - 例外情報。
+ * @returns Error インスタンス。
  */
-function logFatalError(error: unknown): void {
-  const errorDetails = formatErrorDetails(error)
-  const timestamp = new Date().toISOString().replaceAll(':', '-')
-  const logDir = path.join(OUTPUT_DIR, 'logs')
-  const logPath = path.join(logDir, `fatal-error-${timestamp}.log`)
-
-  try {
-    fs.mkdirSync(logDir, { recursive: true })
-    fs.writeFileSync(logPath, errorDetails, 'utf8')
-    console.error(`Fatal error occurred. Details saved to ${logPath}`)
-  } catch {
-    console.error('Fatal error occurred')
-    console.error('Failed to write error log.')
-  }
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
 }
 
 /**
@@ -68,7 +39,7 @@ async function main(): Promise<void> {
     const discordConfig = getDiscordConfig()
     const targetUsername = getTargetUsername(credentials.username)
 
-    console.log('Target user resolved.')
+    logger.info('Target user resolved.')
 
     const { authToken, ct0 } = await getAuthCookies(credentials)
     TwitterOpenApi.fetchApi = cycleTLSFetchWithProxy
@@ -170,10 +141,10 @@ async function main(): Promise<void> {
 
       writeJsonFile(diffPath, diff)
 
-      console.log(
+      logger.info(
         `Followers: +${followersDiff.added.length} / -${followersDiff.removed.length}`
       )
-      console.log(
+      logger.info(
         `Following: +${followingDiff.added.length} / -${followingDiff.removed.length}`
       )
 
@@ -192,23 +163,25 @@ async function main(): Promise<void> {
         })
       }
     } else {
-      console.log('Snapshot saved. No previous data to diff.')
+      logger.info('Snapshot saved. No previous data to diff.')
     }
 
-    console.log(
+    logger.info(
       `Saved followers (${followers.length}) and following (${following.length}).`
     )
   } catch (error) {
-    logFatalError(error)
+    logger.error('Fatal error occurred', toError(error))
     exitCode = 1
   } finally {
     await cleanupCycleTLS()
+    Logger.closeAll()
   }
 
   process.exitCode = exitCode
 }
 
 main().catch((error: unknown) => {
-  logFatalError(error)
+  logger.error('Fatal error occurred', toError(error))
+  Logger.closeAll()
   process.exitCode = 1
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -181,7 +181,10 @@ async function main(): Promise<void> {
 }
 
 main().catch((error: unknown) => {
-  logger.error('Fatal error occurred', toError(error))
+  // main() の finally 内で Logger.closeAll() 済みのためキャッシュがクリアされており、
+  // モジュールスコープの logger をそのまま使うとログが失われる可能性がある。再取得する。
+  const finalLogger = Logger.configure('main')
+  finalLogger.error('Fatal error occurred', toError(error))
   Logger.closeAll()
   process.exitCode = 1
 })

--- a/src/presentation/discord.ts
+++ b/src/presentation/discord.ts
@@ -1,4 +1,7 @@
 import { type UserSnapshot } from '../core/types.js'
+import { Logger } from '@book000/node-utils'
+
+const logger = Logger.configure('discord')
 
 /**
  * Discord Webhook に通知する。
@@ -112,8 +115,9 @@ export async function sendDiscordNotification(
 
   if (!response.ok) {
     const text = await response.text().catch(() => '')
-    console.warn(
-      `Discord webhook failed: ${response.status} ${response.statusText} ${text}`.trim()
+    logger.warn(
+      'Discord webhook failed',
+      new Error(`${response.status} ${response.statusText} ${text}`.trim())
     )
   }
 }


### PR DESCRIPTION
## 概要

Closes #592

`@book000/node-utils` の `Logger` を導入し、`console.*` の直書きを撤去。`SENTRY_DSN` 環境変数が設定されている場合、`.error`/`.warn` ログが自動的に GlitchTip (`glitchtip.orange.amatama.net`) へ転送されるようになります。

## 変更内容

- `package.json` に `@book000/node-utils` (v1.25.8) を追加
- `main.ts` / `infra/auth.ts` / `core/retry.ts` / `app/fetch-users.ts` / `infra/cycletls.ts` / `presentation/discord.ts` の `console.*` (24箇所) を `Logger.configure('<category>')` 経由の呼び出しに置換
- `main.ts` の独自実装 `formatErrorDetails`/`logFatalError` を撤去し、`logger.error('Fatal error occurred', error)` に一本化
- プロセス終了時に `Logger.closeAll()` を呼び、送信をフラッシュ
- `toError()` ヘルパーを改善: `Error` 以外の例外値を `JSON.stringify` で構造化情報を保持しつつ変換し(シリアライズ不能時のみ `String()` にフォールバック)、GlitchTip へ転送されるメッセージ長を 2000 文字に制限(サードパーティ API エラーの HTTP レスポンスヘッダー/ボディ全体の外部送信を抑制)
- `Dockerfile` に `LOG_DIR=/data/logs` を設定し、ログファイルをデータボリューム配下に永続化
- `CLAUDE.md` / `README.md` を Logger ベースの方針に合わせて更新

## 検証内容

- `pnpm lint` / `pnpm lint:tsc` がエラー・警告 0 件であることを確認
- `main.ts` の致命的エラーパスを手動でスモークテストし、ログ出力が期待通り行われることを確認
- 実際の GlitchTip への送信確認は、テスト用の `SENTRY_DSN` が用意できなかったため未実施(コードパス自体は `@book000/node-utils` の実装を確認した上で構成)
- `/deep-review` (ローカル差分モード) を実施し、スコア 50 以上の指摘 4 件をすべて修正済み
- master ブランチとのマージコンフリクト(`pnpm-lock.yaml`)を解消済み(`pnpm install --lockfile-only` で再生成)

## 関連ドキュメント

- Spec: https://github.com/tomacheese/watch-follow-follower/issues/592#issuecomment-5080422640
- Plan: https://github.com/tomacheese/watch-follow-follower/issues/592#issuecomment-5080440411

🤖 Generated with [Claude Code](https://claude.com/claude-code)