### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+data/
+.env
+.env.*


### PR DESCRIPTION
## 概要

`git worktree` 作成時に `data/` と `.env` 系ファイルを新しい worktree にも引き継ぐため、`.worktreeinclude` を追加しました。

## 追加したパターン

```
data/
.env
.env.*
```

## 根拠

- `.gitignore` に `data/`, `.env`, `.env.*` が含まれている
- `README.md` の手順で `cp config.sample.json data/config.json` を実施後、`data/config.json` を編集する運用
- `src/infra/config.ts` で `CONFIG_PATH` のデフォルトが `./data/config.json`、`COOKIE_CACHE_PATH` のデフォルトが `./data/twitter-cookies.json`
- `src/infra/auth.ts` が `data/twitter-cookies.json` の Twitter Cookie キャッシュを読み込む
- `docker-compose.yml` で `./data` をバインドマウントしている
- `data/` には設定ファイル・Cookie キャッシュ・出力スナップショットが含まれ、worktree を切り替えるたびに再ログイン（2FA 含む）が発生することを防ぐため引き継ぎが有用

関連: https://github.com/book000/book000/issues/132
